### PR TITLE
Update caffe to use Visual Studio 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,12 +97,14 @@ MANIFEST-*
 Release/
 Debug/
 3rdparty/
+libraries/
 *.*sdf
 *.deps
 *.suo
 *.suo
 *.pdb
 *.VC.db
+*.opendb
 
 # Python dll dependencies
 python/caffe/*.dll

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wincaffe-3rdparty"]
-	path = 3rdparty
-	url = https://github.com/leizhangcn/wincaffe-3rdparty

--- a/MSVC/CmdParser/CmdParser.csproj
+++ b/MSVC/CmdParser/CmdParser.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>..\..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -26,7 +26,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>..\..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>

--- a/MSVC/caffe.gtest.vcxproj
+++ b/MSVC/caffe.gtest.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -14,18 +14,19 @@
     <ProjectGuid>{B51AE0DD-539B-4DB9-B8E7-1C11424721A4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>caffegtest</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -42,10 +43,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>obj\$(ProjectName)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>obj\$(ProjectName)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -53,17 +56,19 @@
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../include;../src;../3rdparty/include;../3rdparty/include/openblas;../3rdparty/include/hdf5;../3rdparty/include/lmdb;..\cudnn\cuda\include;$(CUDA_PATH)\include;</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS  /FS %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(CUDA_PATH)\include;</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4477;4838;4003%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild />
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\3rdparty\lib;..\3rdparty\lib;..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cudnn.lib;opencv_core249d.lib;opencv_calib3d249d.lib;opencv_contrib249d.lib;opencv_flann249d.lib;opencv_highgui249d.lib;opencv_imgproc249d.lib;opencv_legacy249d.lib;opencv_ml249d.lib;opencv_gpu249d.lib;opencv_objdetect249d.lib;opencv_photo249d.lib;opencv_features2d249d.lib;opencv_nonfree249d.lib;opencv_stitching249d.lib;opencv_video249d.lib;opencv_videostab249d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;libglog.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\libraries\lib;..\libraries\x64\vc14\lib;..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cudnn.lib;opencv_highgui310d.lib;opencv_videoio310d.lib;opencv_imgcodecs310d.lib;opencv_imgproc310d.lib;opencv_core310d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;glogd.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlibd.lib;Shlwapi.lib;boost_system-vc140-mt-gd-1_61.lib;boost_thread-vc140-mt-gd-1_61.lib;boost_filesystem-vc140-mt-gd-1_61.lib;boost_chrono-vc140-mt-gd-1_61.lib;boost_date_time-vc140-mt-gd-1_61.lib;boost_atomic-vc140-mt-gd-1_61.lib;boost_python-vc140-mt-gd-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
     </PostBuildEvent>
@@ -76,9 +81,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../include;../src;../3rdparty/include;../3rdparty/include/openblas;../3rdparty/include/hdf5;../3rdparty/include/lmdb;..\cudnn\cuda\include;$(CUDA_PATH)\include;</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(CUDA_PATH)\include;</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4477;4838;4003;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS  /FS %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -87,15 +92,14 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\3rdparty\lib;..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_core249.lib;opencv_flann249.lib;opencv_imgproc249.lib;opencv_highgui249.lib;opencv_legacy249.lib;opencv_video249.lib;opencv_ml249.lib;opencv_calib3d249.lib;opencv_objdetect249.lib;opencv_stitching249.lib;opencv_gpu249.lib;opencv_nonfree249.lib;opencv_features2d249.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;libglog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\libraries\lib;..\libraries\x64\vc14\lib;..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_highgui310.lib;opencv_imgcodecs310.lib;opencv_imgproc310.lib;opencv_core310.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;glog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlib.lib;Shlwapi.lib;boost_system-vc140-mt-1_61.lib;boost_thread-vc140-mt-1_61.lib;boost_filesystem-vc140-mt-1_61.lib;boost_chrono-vc140-mt-1_61.lib;boost_date_time-vc140-mt-1_61.lib;boost_atomic-vc140-mt-1_61.lib;boost_python-vc140-mt-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\3rdparty\include\mkstemp.cpp" />
     <ClCompile Include="..\src\caffe\test\test_accuracy_layer.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>

--- a/MSVC/caffe.gtest.vcxproj.filters
+++ b/MSVC/caffe.gtest.vcxproj.filters
@@ -207,9 +207,6 @@
     <ClCompile Include="..\src\gtest\gtest-all.cpp">
       <Filter>Source Files\main</Filter>
     </ClCompile>
-    <ClCompile Include="..\3rdparty\include\mkstemp.cpp">
-      <Filter>Source Files\main</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\caffe\test\test_caffe_main.cpp">
       <Filter>Source Files\main</Filter>
     </ClCompile>

--- a/MSVC/caffe.managed/caffe.managed.vcxproj
+++ b/MSVC/caffe.managed/caffe.managed.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -21,14 +21,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -57,19 +57,22 @@
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\3rdparty\include;..\..\3rdparty\include\openblas;..\..\3rdparty\include\hdf5;..\..\3rdparty\include\lmdb;..\..\3rdparty\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\libraries\include;..\..\libraries\include\boost-1_61;..\..\libraries\include\openblas;..\..\libraries\include\hdf5;..\..\libraries\include\lmdb;..\..\libraries\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cudnn.lib;opencv_core249d.lib;opencv_calib3d249d.lib;opencv_contrib249d.lib;opencv_flann249d.lib;opencv_highgui249d.lib;opencv_imgproc249d.lib;opencv_legacy249d.lib;opencv_ml249d.lib;opencv_gpu249d.lib;opencv_objdetect249d.lib;opencv_photo249d.lib;opencv_features2d249d.lib;opencv_nonfree249d.lib;opencv_stitching249d.lib;opencv_video249d.lib;opencv_videostab249d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;libglog.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\3rdparty\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cudnn.lib;opencv_highgui310d.lib;opencv_videoio310d.lib;opencv_imgcodecs310d.lib;opencv_imgproc310d.lib;opencv_core310d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;glogd.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlibd.lib;Shlwapi.lib;boost_system-vc140-mt-gd-1_61.lib;boost_thread-vc140-mt-gd-1_61.lib;boost_filesystem-vc140-mt-gd-1_61.lib;boost_chrono-vc140-mt-gd-1_61.lib;boost_date_time-vc140-mt-gd-1_61.lib;boost_atomic-vc140-mt-gd-1_61.lib;boost_python-vc140-mt-gd-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\libraries\lib;..\..\libraries\x64\vc14\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>
       </LinkTimeCodeGeneration>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+      <IgnoreAllDefaultLibraries>
+      </IgnoreAllDefaultLibraries>
     </Link>
     <PostBuildEvent>
     </PostBuildEvent>
@@ -80,16 +83,16 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
-      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_OPENCV;USE_LEVELDB;USE_LMDB;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\3rdparty\include;..\..\3rdparty\include\openblas;..\..\3rdparty\include\hdf5;..\..\3rdparty\include\lmdb;..\..\3rdparty\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\libraries\include;..\..\libraries\include\boost-1_61;..\..\libraries\include\openblas;..\..\libraries\include\hdf5;..\..\libraries\include\lmdb;..\..\libraries\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cudnn.lib;opencv_core249.lib;opencv_flann249.lib;opencv_imgproc249.lib;opencv_highgui249.lib;opencv_legacy249.lib;opencv_video249.lib;opencv_ml249.lib;opencv_calib3d249.lib;opencv_objdetect249.lib;opencv_stitching249.lib;opencv_gpu249.lib;opencv_nonfree249.lib;opencv_features2d249.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;libglog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\3rdparty\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_highgui310.lib;opencv_imgcodecs310.lib;opencv_imgproc310.lib;opencv_core310.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;glog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlib.lib;Shlwapi.lib;boost_system-vc140-mt-1_61.lib;boost_thread-vc140-mt-1_61.lib;boost_filesystem-vc140-mt-1_61.lib;boost_chrono-vc140-mt-1_61.lib;boost_date_time-vc140-mt-1_61.lib;boost_atomic-vc140-mt-1_61.lib;boost_python-vc140-mt-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\libraries\lib;..\..\libraries\x64\vc14\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>

--- a/MSVC/caffe.managed/caffelib.cpp
+++ b/MSVC/caffe.managed/caffelib.cpp
@@ -1,12 +1,14 @@
 #include "stdafx.h"
 
-using namespace std;
 using namespace System;
 using namespace System::Runtime::InteropServices;
 using namespace System::Collections::Generic;
 using namespace System::IO;
 using namespace System::Drawing;
 using namespace System::Drawing::Imaging;
+
+using std::vector;
+using std::string;
 
 #define TO_NATIVE_STRING(str) msclr::interop::marshal_as<std::string>(str)
 #define MARSHAL_ARRAY(n_array, m_array) \

--- a/MSVC/caffe.native/caffe.native.vcxproj
+++ b/MSVC/caffe.native/caffe.native.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -54,18 +54,19 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>USE_OPENCV;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAFFENATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\3rdparty\include;..\..\3rdparty\include\openblas;..\..\3rdparty\include\hdf5;..\..\3rdparty\include\lmdb;..\..\3rdparty\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;USE_OPENCV;WIN32;_DEBUG;_WINDOWS;_USRDLL;CAFFENATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\libraries\include;..\..\libraries\include\boost-1_61;..\..\libraries\include\openblas;..\..\libraries\include\hdf5;..\..\libraries\include\lmdb;..\..\libraries\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>Async</ExceptionHandling>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4003;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\3rdparty\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cudnn.lib;opencv_core249d.lib;opencv_calib3d249d.lib;opencv_contrib249d.lib;opencv_flann249d.lib;opencv_highgui249d.lib;opencv_imgproc249d.lib;opencv_legacy249d.lib;opencv_ml249d.lib;opencv_gpu249d.lib;opencv_objdetect249d.lib;opencv_photo249d.lib;opencv_features2d249d.lib;opencv_nonfree249d.lib;opencv_stitching249d.lib;opencv_video249d.lib;opencv_videostab249d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;libglog.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\libraries\lib;..\..\libraries\x64\vc14\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cudnn.lib;opencv_highgui310d.lib;opencv_videoio310d.lib;opencv_imgcodecs310d.lib;opencv_imgproc310d.lib;opencv_core310d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;glogd.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlibd.lib;Shlwapi.lib;boost_system-vc140-mt-gd-1_61.lib;boost_thread-vc140-mt-gd-1_61.lib;boost_filesystem-vc140-mt-gd-1_61.lib;boost_chrono-vc140-mt-gd-1_61.lib;boost_date_time-vc140-mt-gd-1_61.lib;boost_atomic-vc140-mt-gd-1_61.lib;boost_python-vc140-mt-gd-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ProjectReference>
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
@@ -80,10 +81,10 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>USE_OPENCV;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAFFENATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\3rdparty\include;..\..\3rdparty\include\openblas;..\..\3rdparty\include\hdf5;..\..\3rdparty\include\lmdb;..\..\3rdparty\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;USE_OPENCV;WIN32;NDEBUG;_WINDOWS;_USRDLL;CAFFENATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\include;..\..\src;..\..\libraries\include;..\..\libraries\include\boost-1_61;..\..\libraries\include\openblas;..\..\libraries\include\hdf5;..\..\libraries\include\lmdb;..\..\libraries\include\opencv;..\..\cudnn\cuda\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Async</ExceptionHandling>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4003;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -91,8 +92,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\3rdparty\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cudnn.lib;opencv_core249.lib;opencv_flann249.lib;opencv_imgproc249.lib;opencv_highgui249.lib;opencv_legacy249.lib;opencv_video249.lib;opencv_ml249.lib;opencv_calib3d249.lib;opencv_objdetect249.lib;opencv_stitching249.lib;opencv_gpu249.lib;opencv_nonfree249.lib;opencv_features2d249.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;libglog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\lib\$(Configuration);..\..\libraries\lib;..\..\libraries\x64\vc14\lib;..\..\cudnn\cuda\lib\$(PlatformName);$(CUDA_PATH)\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories))</AdditionalLibraryDirectories>
+      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_highgui310.lib;opencv_imgcodecs310.lib;opencv_imgproc310.lib;opencv_core310.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;glog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlib.lib;Shlwapi.lib;boost_system-vc140-mt-1_61.lib;boost_thread-vc140-mt-1_61.lib;boost_filesystem-vc140-mt-1_61.lib;boost_chrono-vc140-mt-1_61.lib;boost_date_time-vc140-mt-1_61.lib;boost_atomic-vc140-mt-1_61.lib;boost_python-vc140-mt-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ProjectReference>
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>

--- a/MSVC/caffe.python.vcxproj
+++ b/MSVC/caffe.python.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -32,18 +32,19 @@
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
     <SccProvider>SAK</SccProvider>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -63,12 +64,14 @@
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <TargetExt>.pyd</TargetExt>
     <TargetName>_caffe</TargetName>
+    <IntDir>obj\$(ProjectName)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <TargetExt>.pyd</TargetExt>
     <TargetName>_caffe</TargetName>
+    <IntDir>obj\$(ProjectName)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -76,27 +79,26 @@
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;WIN32;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>../include;../src;../3rdparty/include;../3rdparty/include/openblas;../3rdparty/include/hdf5;../3rdparty/include/lmdb;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(PYTHON_ROOT)\Lib\site-packages\numpy\core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../include;../src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(PYTHON_ROOT)\Lib\site-packages\numpy\core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4003;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>cudnn.lib;opencv_core249d.lib;opencv_calib3d249d.lib;opencv_contrib249d.lib;opencv_flann249d.lib;opencv_highgui249d.lib;opencv_imgproc249d.lib;opencv_legacy249d.lib;opencv_ml249d.lib;opencv_gpu249d.lib;opencv_objdetect249d.lib;opencv_photo249d.lib;opencv_features2d249d.lib;opencv_nonfree249d.lib;opencv_stitching249d.lib;opencv_video249d.lib;opencv_videostab249d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;libglog.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\cudnn\cuda\lib\$(PlatformName);../3rdparty/lib;$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cudnn.lib;opencv_highgui310d.lib;opencv_videoio310d.lib;opencv_imgcodecs310d.lib;opencv_imgproc310d.lib;opencv_core310d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;glogd.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlibd.lib;Shlwapi.lib;boost_system-vc140-mt-gd-1_61.lib;boost_thread-vc140-mt-gd-1_61.lib;boost_filesystem-vc140-mt-gd-1_61.lib;boost_chrono-vc140-mt-gd-1_61.lib;boost_date_time-vc140-mt-gd-1_61.lib;boost_atomic-vc140-mt-gd-1_61.lib;boost_python-vc140-mt-gd-1_61.lib;python27.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\cudnn\cuda\lib\$(PlatformName);..\libraries\lib;..\libraries\x64\vc14\lib;$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>scripts/PyProtoCompile.cmd "$(SolutionDir)" "$(SolutionDir)libraries\bin\"</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>robocopy $(SolutionDir)3rdparty\bin $(SolutionDir)python\caffe 2&gt;nul 1&gt;nul
-robocopy $(SolutionDir)bin\$(Configuration) $(SolutionDir)python\caffe _caffe.p* 2&gt;nul 1&gt;nul
-robocopy $(SolutionDir)cudnn\cuda\bin $(SolutionDir)python\caffe 2&gt;nul 1&gt;nul
-EXIT 0</Command>
+      <Command>call scripts/CaffeLibPostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)python\caffe"
+call scripts/PyCaffePostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)python\caffe"
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -107,29 +109,27 @@ EXIT 0</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WITH_PYTHON_LAYER;WIN32;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>../include;../src;../3rdparty/include;../3rdparty/include/openblas;../3rdparty/include/hdf5;../3rdparty/include/lmdb;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(PYTHON_ROOT)\Lib\site-packages\numpy\core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../include;../src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(PYTHON_ROOT)\Lib\site-packages\numpy\core\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4661;4005;4812;4715;4003;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>cudnn.lib;opencv_core249.lib;opencv_flann249.lib;opencv_imgproc249.lib;opencv_highgui249.lib;opencv_legacy249.lib;opencv_video249.lib;opencv_ml249.lib;opencv_calib3d249.lib;opencv_objdetect249.lib;opencv_stitching249.lib;opencv_gpu249.lib;opencv_nonfree249.lib;opencv_features2d249.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;libglog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\cudnn\cuda\lib\$(PlatformName);../3rdparty/lib;$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_highgui310.lib;opencv_imgcodecs310.lib;opencv_imgproc310.lib;opencv_core310.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;glog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlib.lib;Shlwapi.lib;boost_system-vc140-mt-1_61.lib;boost_thread-vc140-mt-1_61.lib;boost_filesystem-vc140-mt-1_61.lib;boost_chrono-vc140-mt-1_61.lib;boost_date_time-vc140-mt-1_61.lib;boost_atomic-vc140-mt-1_61.lib;boost_python-vc140-mt-1_61.lib;python27.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\cudnn\cuda\lib\$(PlatformName);..\libraries\lib;..\libraries\x64\vc14\lib;$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>scripts/PyProtoCompile.cmd "$(SolutionDir)" "$(SolutionDir)libraries\bin\"</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>robocopy $(SolutionDir)3rdparty\bin $(SolutionDir)python\caffe 2&gt;nul 1&gt;nul
-robocopy $(SolutionDir)bin\$(Configuration) $(SolutionDir)python\caffe _caffe.p* 2&gt;nul 1&gt;nul
-robocopy $(SolutionDir)cudnn\cuda\bin $(SolutionDir)python\caffe 2&gt;nul 1&gt;nul
-EXIT 0</Command>
+      <Command>call scripts/CaffeLibPostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)python\caffe"
+call scripts/PyCaffePostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)python\caffe"
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/MSVC/caffe.vcxproj
+++ b/MSVC/caffe.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -20,13 +20,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -60,17 +60,18 @@
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WITH_PYTHON_LAYER;WIN32;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_CUDNN;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\include;..\src;..\3rdparty\include;..\3rdparty\include\openblas;..\3rdparty\include\hdf5;..\3rdparty\include\lmdb;..\3rdparty\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS  /FS %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\3rdparty\lib;..\3rdparty\lib;..\cudnn\cuda\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cudnn.lib;opencv_core249d.lib;opencv_calib3d249d.lib;opencv_contrib249d.lib;opencv_flann249d.lib;opencv_highgui249d.lib;opencv_imgproc249d.lib;opencv_legacy249d.lib;opencv_ml249d.lib;opencv_gpu249d.lib;opencv_objdetect249d.lib;opencv_photo249d.lib;opencv_features2d249d.lib;opencv_nonfree249d.lib;opencv_stitching249d.lib;opencv_video249d.lib;opencv_videostab249d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;libglog.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\libraries\lib;..\libraries\x64\vc14\lib;..\cudnn\cuda\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cudnn.lib;opencv_highgui310d.lib;opencv_videoio310d.lib;opencv_imgcodecs310d.lib;opencv_imgproc310d.lib;opencv_core310d.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflagsd.lib;glogd.lib;libopenblas.dll.a;libprotobufd.lib;libprotoc.lib;leveldbd.lib;lmdbd.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlibd.lib;Shlwapi.lib;boost_system-vc140-mt-gd-1_61.lib;boost_thread-vc140-mt-gd-1_61.lib;boost_filesystem-vc140-mt-gd-1_61.lib;boost_chrono-vc140-mt-gd-1_61.lib;boost_date_time-vc140-mt-gd-1_61.lib;boost_atomic-vc140-mt-gd-1_61.lib;boost_python-vc140-mt-gd-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent />
     <PostBuildEvent />
@@ -83,9 +84,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WITH_PYTHON_LAYER;WIN32;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;WIN32;USE_CUDNN;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\include;..\src;..\3rdparty\include;..\3rdparty\include\openblas;..\3rdparty\include\hdf5;..\3rdparty\include\lmdb;..\3rdparty\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\lmdb;..\libraries\include\opencv;..\cudnn\cuda\include;$(PYTHON_ROOT)\include;$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS  /FS %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
@@ -94,8 +95,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>lib\$(Configuration);..\3rdparty\lib;..\cudnn\cuda\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_core249.lib;opencv_flann249.lib;opencv_imgproc249.lib;opencv_highgui249.lib;opencv_legacy249.lib;opencv_video249.lib;opencv_ml249.lib;opencv_calib3d249.lib;opencv_objdetect249.lib;opencv_stitching249.lib;opencv_gpu249.lib;opencv_nonfree249.lib;opencv_features2d249.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;libglog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libzlib.lib;libszip.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>lib\$(Configuration);..\libraries\lib;..\libraries\x64\vc14\lib;..\cudnn\cuda\lib\$(PlatformName);$(PYTHON_ROOT)/libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>caffe.lib;cudnn.lib;opencv_highgui310.lib;opencv_imgcodecs310.lib;opencv_imgproc310.lib;opencv_core310.lib;cudart.lib;cuda.lib;nppi.lib;cufft.lib;cublas.lib;curand.lib;gflags.lib;glog.lib;libopenblas.dll.a;libprotobuf.lib;libprotoc.lib;leveldb.lib;lmdb.lib;ntdll.lib;libcaffehdf5.lib;libcaffehdf5_hl.lib;caffezlib.lib;Shlwapi.lib;boost_system-vc140-mt-1_61.lib;boost_thread-vc140-mt-1_61.lib;boost_filesystem-vc140-mt-1_61.lib;boost_chrono-vc140-mt-1_61.lib;boost_date_time-vc140-mt-1_61.lib;boost_atomic-vc140-mt-1_61.lib;boost_python-vc140-mt-1_61.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent />
     <ProjectReference>

--- a/MSVC/caffelib.vcxproj
+++ b/MSVC/caffelib.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -20,13 +20,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -60,32 +60,31 @@
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <CodeGeneration>$(CudaArchitecture)</CodeGeneration>
       <GenerateLineInfo>true</GenerateLineInfo>
-      <AdditionalOptions>-Xcudafe "--diag_suppress=exception_spec_override_incompat --diag_suppress=useless_using_declaration" -D_SCL_SECURE_NO_WARNINGS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-Xcudafe "--diag_suppress=exception_spec_override_incompat --diag_suppress=useless_using_declaration" -D_SCL_SECURE_NO_WARNINGS -Wno-deprecated-gpu-targets %(AdditionalOptions)</AdditionalOptions>
     </CudaCompile>
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WITH_PYTHON_LAYER;USE_CUDNN;USE_OPENCV;USE_LEVELDB;USE_LMDB;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;USE_CUDNN;USE_OPENCV;USE_LEVELDB;USE_LMDB;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\include;..\src;..\3rdparty\include;..\3rdparty\include\openblas;..\3rdparty\include\hdf5;..\3rdparty\include\lmdb;..\3rdparty\include\opencv;$(PYTHON_ROOT)\include;..\cudnn\cuda\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\opencv;$(PYTHON_ROOT)\include;..\cudnn\cuda\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS   /FS %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <PreBuildEvent>
-      <Command>../scripts/GeneratePB.bat</Command>
+      <Command>scripts/ProtoCompile.cmd "$(SolutionDir)" "$(SolutionDir)libraries\bin\"</Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>robocopy ..\3rdparty\bin $(SolutionDir)bin\$(Configuration) /xo /xn
-robocopy ..\cudnn\cuda\bin $(SolutionDir)bin\$(Configuration) /xo /xn
-IF %ERRORLEVEL% GEQ 8 exit 1
-exit 0</Command>
+      <Command>scripts/CaffeLibPostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)bin\$(CONFIGURATION)"</Command>
     </PostBuildEvent>
     <Lib>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Lib>
     <CudaCompile>
       <CodeGeneration>compute_61,sm_61</CodeGeneration>
@@ -95,7 +94,7 @@ exit 0</Command>
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <CodeGeneration>$(CudaArchitecture)</CodeGeneration>
-      <AdditionalOptions>-Xcudafe "--diag_suppress=exception_spec_override_incompat --diag_suppress=useless_using_declaration" -D_SCL_SECURE_NO_WARNINGS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-Xcudafe "--diag_suppress=exception_spec_override_incompat --diag_suppress=useless_using_declaration" -D_SCL_SECURE_NO_WARNINGS -Wno-deprecated-gpu-targets %(AdditionalOptions)</AdditionalOptions>
     </CudaCompile>
     <ClCompile>
       <WarningLevel>Level1</WarningLevel>
@@ -104,15 +103,15 @@ exit 0</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WITH_PYTHON_LAYER;USE_CUDNN;USE_OPENCV;USE_LEVELDB;USE_LMDB;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_PYTHON_LAYER;BOOST_ALL_NO_LIB;BOOST_NO_CXX11_TEMPLATE_ALIASES;USE_CUDNN;USE_OPENCV;USE_LEVELDB;USE_LMDB;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\include;..\src;..\3rdparty\include;..\3rdparty\include\openblas;..\3rdparty\include\hdf5;..\3rdparty\include\lmdb;..\3rdparty\include\opencv;$(PYTHON_ROOT)\include;..\cudnn\cuda\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\src;..\libraries\include;..\libraries\include\boost-1_61;..\libraries\include\openblas;..\libraries\include\hdf5;..\libraries\include\opencv;$(PYTHON_ROOT)\include;..\cudnn\cuda\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/Zo  /FS</AdditionalOptions>
       <DisableSpecificWarnings>4661;4005;4812;4715;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <PreBuildEvent>
-      <Command>../scripts/GeneratePB.bat</Command>
+      <Command>scripts/ProtoCompile.cmd "$(SolutionDir)" "$(SolutionDir)libraries\bin\"</Command>
     </PreBuildEvent>
     <CudaCompile>
       <CodeGeneration>compute_61,sm_61</CodeGeneration>
@@ -123,10 +122,7 @@ exit 0</Command>
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>
     </Lib>
     <PostBuildEvent>
-      <Command>robocopy ..\3rdparty\bin $(SolutionDir)bin\$(Configuration) /xo /xn
-robocopy ..\cudnn\cuda\bin $(SolutionDir)bin\$(Configuration) /xo /xn
-IF %ERRORLEVEL% GEQ 8 exit 1
-exit 0</Command>
+      <Command>scripts/CaffeLibPostBuild.cmd "$(SolutionDir)" "$(Configuration)" "$(SolutionDir)bin\$(CONFIGURATION)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -316,7 +312,6 @@ exit 0</Command>
   <ItemGroup>
     <ClInclude Include="..\include\caffe\blob.hpp" />
     <ClInclude Include="..\include\caffe\caffe.hpp" />
-    <ClInclude Include="..\include\caffe\caffe.pb.h" />
     <ClInclude Include="..\include\caffe\common.hpp" />
     <ClInclude Include="..\include\caffe\data_reader.hpp" />
     <ClInclude Include="..\include\caffe\data_transformer.hpp" />

--- a/MSVC/caffelib.vcxproj.filters
+++ b/MSVC/caffelib.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <CudaCompile Include="..\src\caffe\layers\absval_layer.cu">
@@ -770,9 +770,6 @@
     <ClInclude Include="..\include\caffe\layers\mil_layer.hpp">
       <Filter>Head Files\layers</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\caffe\caffe.pb.h">
-      <Filter>Head Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\include\caffe\data_reader.hpp">
       <Filter>Head Files</Filter>
     </ClInclude>
@@ -894,6 +891,8 @@
       <Filter>Head Files\layers</Filter>
     </ClInclude>
     <ClInclude Include="..\include\caffe\layers\roi_pooling_layer.hpp">
+      <Filter>Head Files\layers</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\caffe\layers\wsgm_loss_layer.hpp">
       <Filter>Head Files\layers</Filter>
     </ClInclude>

--- a/MSVC/scripts/CaffeLibPostBuild.cmd
+++ b/MSVC/scripts/CaffeLibPostBuild.cmd
@@ -1,0 +1,19 @@
+echo off
+
+set SOLUTION_DIR=%~1%
+set CONFIGURATION=%~2% 
+set OUTPUT_DIR=%~3%
+
+IF /I %CONFIGURATION% == Release (
+echo CaffeLibPostBuild.cmd : copy caffe RELEASE dependencies to output.
+robocopy "%SOLUTION_DIR%libraries\bin" "%OUTPUT_DIR%" caffe*.dll lib*.dll glog.dll snappy.dll vcruntime140.dll /xo /xn /xf *d.dll *d1.dll >nul
+robocopy "%SOLUTION_DIR%libraries\lib" "%OUTPUT_DIR%" gflags.dll boost_system*.dll boost_thread*.dll boost_filesystem*.dll boost_python*.dll boost_chrono*.dll /xo /xn /xf *gd*.dll >nul
+robocopy "%SOLUTION_DIR%libraries\x64\vc14\bin" "%OUTPUT_DIR%" opencv_core*.dll opencv_imgproc*.dll opencv_imgcodecs*.dll opencv_highgui*.dll opencv_videoio*.dll /xo /xn /xf *d.dll >nul
+robocopy "%SOLUTION_DIR%cudnn\cuda\bin" "%OUTPUT_DIR%" cudnn*.dll /xo /xn >nul
+) ELSE (
+echo CaffeLibPostBuild.cmd : copy caffe DEBUG dependencies to output.
+robocopy "%SOLUTION_DIR%libraries\bin" "%OUTPUT_DIR%" caffe*d.dll caffe*d1.dll lib*.dll glogd.dll snappyd.dll vcruntime140.dll /xo /xn /xf  >nul
+robocopy "%SOLUTION_DIR%libraries\lib" "%OUTPUT_DIR%" gflagsd.dll boost_system*gd*.dll boost_thread*gd*.dll boost_filesystem*gd*.dll boost_python*gd*.dll boost_chrono*gd*.dll /xo /xn >nul
+robocopy "%SOLUTION_DIR%libraries\x64\vc14\bin" "%OUTPUT_DIR%" opencv_core*d.dll opencv_imgproc*d.dll opencv_imgcodecs*d.dll opencv_highgui*d.dll opencv_videoio*d.dll /xo /xn >nul
+robocopy "%SOLUTION_DIR%cudnn\cuda\bin" "%OUTPUT_DIR%" cudnn*.dll /xo /xn  >nul
+)

--- a/MSVC/scripts/ProtoCompile.cmd
+++ b/MSVC/scripts/ProtoCompile.cmd
@@ -1,0 +1,22 @@
+set SOLUTION_DIR=%~1%
+set PROTO_DIR=%~2%
+
+SET SRC_PROTO_DIR=%SOLUTION_DIR%src\caffe\proto
+set PROTO_TEMP_DIR=%SRC_PROTO_DIR%\temp
+
+echo ProtoCompile.cmd : Create proto temp directory "%PROTO_TEMP_DIR%"
+mkdir "%PROTO_TEMP_DIR%"
+
+echo ProtoCompile.cmd : Generating "%PROTO_TEMP_DIR%\caffe.pb.h" and "%PROTO_TEMP_DIR%\caffe.pb.cc"
+"%PROTO_DIR%protoc" --proto_path="%SRC_PROTO_DIR%" --cpp_out="%PROTO_TEMP_DIR%" "%SRC_PROTO_DIR%\caffe.proto"
+
+echo ProtoCompile.cmd : Compare newly compiled caffe.pb.h with existing one
+fc /b "%PROTO_TEMP_DIR%\caffe.pb.h" "%SRC_PROTO_DIR%\caffe.pb.h" > NUL
+
+if errorlevel 1 (
+    echo ProtoCompile.cmd : Move newly generated caffe.pb.cc/h to "%SRC_PROTO_DIR%"
+    move /y "%PROTO_TEMP_DIR%\caffe.pb.h" "%SRC_PROTO_DIR%\caffe.pb.h"
+    move /y "%PROTO_TEMP_DIR%\caffe.pb.cc" "%SRC_PROTO_DIR%\caffe.pb.cc"
+)
+
+rmdir /S /Q "%PROTO_TEMP_DIR%"

--- a/MSVC/scripts/PyCaffePostBuild.cmd
+++ b/MSVC/scripts/PyCaffePostBuild.cmd
@@ -1,0 +1,8 @@
+echo off
+
+set SOLUTION_DIR=%~1%
+set CONFIGURATION=%~2% 
+set OUTPUT_DIR=%~3%
+
+echo PyCaffePostBuild.cmd : copy _caffe.pyd to output
+robocopy "%SOLUTION_DIR%bin\%CONFIGURATION%" "%OUTPUT_DIR%" _caffe.p* /xo /xn >nul

--- a/MSVC/scripts/PyProtoCompile.cmd
+++ b/MSVC/scripts/PyProtoCompile.cmd
@@ -1,0 +1,22 @@
+set SOLUTION_DIR=%~1%
+set PROTO_DIR=%~2%
+
+SET SRC_PROTO_DIR=%SOLUTION_DIR%src\caffe\proto
+set PROTO_TEMP_DIR=%SRC_PROTO_DIR%\temp
+set PROTO_OUT_DIR=%SOLUTION_DIR%python\caffe\proto
+
+echo PyProtoCompile.cmd : Create proto temp directory "%PROTO_TEMP_DIR%"
+mkdir "%PROTO_TEMP_DIR%"
+
+echo PyProtoCompile.cmd : Generating "%PROTO_TEMP_DIR%\caffe_pb2.py"
+"%PROTO_DIR%protoc" --proto_path="%SRC_PROTO_DIR%" --python_out="%PROTO_TEMP_DIR%" "%SRC_PROTO_DIR%\caffe.proto"
+
+echo PyProtoCompile.cmd : Compare newly compiled caffe_pb2.py with existing one
+fc /b "%PROTO_TEMP_DIR%\caffe_pb2.py" "%PROTO_OUT_DIR%\caffe_pb2.py" > NUL
+
+if errorlevel 1 (
+    echo ProtoCompile-py.cmd : Move newly generated caffe_pb2.py to "%PROTO_OUT_DIR%"
+    move /y "%PROTO_TEMP_DIR%\caffe_pb2.py" "%PROTO_OUT_DIR%\caffe_pb2.py"
+)
+
+rmdir /S /Q "%PROTO_TEMP_DIR%"

--- a/README.md
+++ b/README.md
@@ -17,34 +17,32 @@ and step-by-step examples.
 
 **Note**: This repo is ported from `git@github.com:MSRDL/caffe.git` for research development. The **master** branch follows BVLC/Caffe master, and the **WinCaffe** branch will merge the latest changes from **master** and keep it compilable in Windows.
 
+## Prerequisite
+1. Visual Studio 2015
+2. Python 2.7 - Anaconda is recommended: https://www.continuum.io/downloads
+3. Cuda 8.0
+ 
 ## Windows Setup
-**Requirements**: Visual Studio 2013 (Visual Studio 2015 is not supported at this moment) and CUDA 7.5
+1. Clone the repository:
 
-Please recursively clone the repository via:
+   ```
+   git clone https://github.com/MSRCCS/Caffe.git
+   ```
+2. Download 3rd party dependencies - under the caffe root folder, run:
 
-```
-git clone git@github.com:MSRCCS/caffe.git --recursive
-```
+   ```
+   python .\scripts\download_prebuilt_dependencies.py
+   ```
+3. Download `cuDNN v5.0` [from nVidia website](https://developer.nvidia.com/cudnn). Please specifically select v5 of CuDnn, which is the version that verifies to build with this WinCaffe package. 
+   Then under the caffe root folder, run `.\scripts\installCuDNN.ps1 $downloadedZipFile` in PowerShell where `$downloadedZipFile` is the path to your downloaded cuDNN file. Example: `.\scripts\installCuDNN.ps1 ~\Downloads\cudnn-7.5-win-x64-v5.0-prod.zip`
 
-Download `cuDNN` [from nVidia website](https://developer.nvidia.com/cudnn). Please specifically select v3 of CuDnn, which is the version that verifies to build with this WinCaffe package. 
-Then run `.\scripts\installCuDNN.ps1 $downloadedZipFile` in PowerShell where `$downloadedZipFile` is the path to your downloaded cuDNN file. Example: `.\scripts\installCuDNN.ps1 ~\Downloads\cudnn-7.0-win-x64-v3.0-prod.zip`
-
-Now, you should be able to build `caffe.sln`, except for the caffe.python project. Please build using Microsoft Visual Studio 2013. 
+Now, you should be able to build `caffe.sln` in Visual Studio 2015.
 
 ## Python Setup
 To build caffe.python and use the python wrapper on Windows, please follow [Python Setup](python/SetupPython.md) to setup the python environment. 
 
-## Development
-
 ### Common issues when pulling new commits from BVLC's branch
-- If compilation fails: regenerate `caffe.pb.h` and `caffe.pb.cc` files. This can be done by removing `src\caffe\proto\caffe.pb.h` file. The build process will regenerate if this file is missing.
 - If linking fails: it's likely that there are new `cpp` files that need to be added to the `caffelib` project.
-
-## Development
-
-### Common issues when syncing from main branch
-- If compilation fails: regenerate `caffe.pb.h` and `caffe.pb.cc` files. This can be done by removing `src\caffe\proto\caffe.pb.h` file. The build process will regenerate if this file is missing.
-- If linking fails: it's likely that there are new `cpp` files that need to be added to the `caffelib` project so that they are compiled.
 
 ## License and Citation
 

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -1,7 +1,7 @@
 #ifndef CAFFE_UTIL_IO_H_
 #define CAFFE_UTIL_IO_H_
 
-#include <unistd.h>
+//#include <unistd.h>
 #include <boost/filesystem.hpp>
 #include <iomanip>
 #include <iostream>  // NOLINT(readability/streams)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -1,11 +1,3 @@
-#ifdef _DEBUG
-#undef _DEBUG
-#include <Python.h>
-#define _DEBUG
-#else
-#include <Python.h>  // NOLINT(build/include_alpha)
-#endif
-
 // Produce deprecation warnings (needs to come before arrayobject.h inclusion).
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -13,7 +5,6 @@
 #include <boost/python.hpp>
 #include <boost/python/raw_function.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/python/enum.hpp>
 #include <numpy/arrayobject.h>
 
 // these need to be included after boost on OS X
@@ -45,6 +36,32 @@
     bp::register_ptr_to_python<shared_ptr<PTR > >(); \
   } \
 } while (0)
+
+#if defined(_MSC_VER) && (_MSC_FULL_VER >= 190024210)
+// Workaround for VS 2015 Update 3 which breaks boost python
+// See: http://stackoverflow.com/questions/38261530/unresolved-external-symbols-since-visual-studio-2015-update-3-boost-python-link
+// and https://msdn.microsoft.com/vs-knownissues/vs2015-update3
+#define BP_GET_POINTER(cls, dtype) \
+namespace boost { \
+template <> \
+caffe::cls<dtype> const volatile * \
+get_pointer<class caffe::cls<dtype> const volatile >( \
+  class caffe::cls<dtype> const volatile *c) { \
+    return c; \
+} \
+}
+
+BP_GET_POINTER(Net, float);
+BP_GET_POINTER(Layer, float);
+BP_GET_POINTER(Solver, float);
+BP_GET_POINTER(SGDSolver, float);
+BP_GET_POINTER(NesterovSolver, float);
+BP_GET_POINTER(AdaGradSolver, float);
+BP_GET_POINTER(RMSPropSolver, float);
+BP_GET_POINTER(AdaDeltaSolver, float);
+BP_GET_POINTER(AdamSolver, float);
+
+#endif
 
 namespace bp = boost::python;
 

--- a/scripts/GeneratePB.bat
+++ b/scripts/GeneratePB.bat
@@ -1,8 +1,0 @@
-if exist "../src/caffe/proto/caffe.pb.h" (
-    echo caffe.pb.h remains the same as before
-) else (
-    echo caffe.pb.h is being generated
-    ..\3rdparty\tools\protoc -I="../src/caffe/proto" --cpp_out="../src/caffe/proto" "../src/caffe/proto/caffe.proto"
-    copy "..\src\caffe\proto\caffe.pb.h" "..\include\caffe\caffe.pb.h"
-)
-

--- a/scripts/GeneratePB_py.bat
+++ b/scripts/GeneratePB_py.bat
@@ -1,8 +1,0 @@
-if exist "../python/caffe/proto/caffe_pb2.py" (
-    echo caffe_pb2.py remains the same as before
-) else (
-    echo caffe_pb2.py is being generated
-	..\3rdparty\tools\protoc -I="../src/caffe/proto" --python_out="../src/caffe/proto" "../src/caffe/proto/caffe.proto"
-    copy "..\src\caffe\proto\caffe_pb2.py" "..\python\caffe\proto\caffe_pb2.py"
-)
-

--- a/scripts/download_prebuilt_dependencies.py
+++ b/scripts/download_prebuilt_dependencies.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+#
+# copyright Guillaume Dumont (2016)
+
+import os
+import sys
+import hashlib
+import argparse
+import tarfile
+
+from six.moves import urllib
+from download_model_binary import reporthook
+
+WIN_DEPENDENCIES_URLS = {
+    ('v120', '2.7'):("https://github.com/willyd/caffe-builder/releases/download/v1.0.1/libraries_v120_x64_py27_1.0.1.tar.bz2",
+                  "3f45fe3f27b27a7809f9de1bd85e56888b01dbe2"),
+    ('v140', '2.7'):("https://github.com/willyd/caffe-builder/releases/download/v1.0.1/libraries_v140_x64_py27_1.0.1.tar.bz2",
+                  "427faf33745cf8cd70c7d043c85db7dda7243122"),
+    ('v140', '3.5'):("https://github.com/willyd/caffe-builder/releases/download/v1.0.1/libraries_v140_x64_py35_1.0.1.tar.bz2",
+                  "1f55dac54aeab7ae3a1cda145ca272dea606bdf9"),
+}
+
+# function for checking SHA1.
+def model_checks_out(filename, sha1):
+    with open(filename, 'rb') as f:
+        return hashlib.sha1(f.read()).hexdigest() == sha1
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Download prebuilt dependencies for windows.')
+    parser.add_argument('--msvc_version', default='v140', choices=['v120', 'v140'])
+    args = parser.parse_args()
+
+    assert args.msvc_version == 'v140', 'Only Visual Studio 2015 is supported!'
+
+    # get the appropriate url
+    pyver = '{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor)
+    assert pyver == '2.7', 'Only Python 2.7 is supported!'
+    try:
+        url, sha1 = WIN_DEPENDENCIES_URLS[(args.msvc_version, pyver)]
+    except KeyError:
+        print('ERROR: Could not find url for MSVC version = {} and Python version = {}.\n{}'
+              .format(args.msvc_version, pyver,
+              'Available combinations are: {}'.format(list(WIN_DEPENDENCIES_URLS.keys()))))
+        sys.exit(1)
+
+    dep_filename = os.path.split(url)[1]
+    # Download binaries
+    print("Downloading dependencies ({}). Please wait...".format(dep_filename))
+    urllib.request.urlretrieve(url, dep_filename, reporthook)
+    if not model_checks_out(dep_filename, sha1):
+        print('ERROR: dependencies did not download correctly! Run this again.')
+        sys.exit(1)
+    print("\nDone.")
+
+    # Extract the binaries from the tar file
+    tar = tarfile.open(dep_filename, 'r:bz2')
+    print("Extracting dependencies. Please wait...")
+    tar.extractall()
+    print("Done.")
+    tar.close()
+    os.remove(dep_filename)

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -1,4 +1,8 @@
 #include <fcntl.h>
+#if defined(_MSC_VER)
+#include <io.h>
+#endif
+
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>


### PR DESCRIPTION
1. Remove the dependency to 3rdparty (https://github.com/leizhangcn/wincaffe-3rdparty)
2. Instead, use the dependency files from https://github.com/willyd/caffe-builder, which is used by the BVLC wincaffe branch.
3. Add pre/post build cmd files to simplify the commands in vcxproj files
4. Update README.md for the latest installation instructions