### PR TITLE
Fix caffe build issues caused by cuda architecture and robocopy

### DIFF
--- a/MSVC/caffelib.vcxproj
+++ b/MSVC/caffelib.vcxproj
@@ -87,7 +87,7 @@
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Lib>
     <CudaCompile>
-      <CodeGeneration>compute_61,sm_61</CodeGeneration>
+      <CodeGeneration>compute_35,sm_35;compute_52,sm_52;compute_61,sm_61</CodeGeneration>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -114,7 +114,7 @@
       <Command>scripts/ProtoCompile.cmd "$(SolutionDir)" "$(SolutionDir)libraries\bin\"</Command>
     </PreBuildEvent>
     <CudaCompile>
-      <CodeGeneration>compute_61,sm_61</CodeGeneration>
+      <CodeGeneration>compute_35,sm_35;compute_52,sm_52;compute_61,sm_61</CodeGeneration>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <Defines>USE_CUDNN</Defines>
     </CudaCompile>

--- a/MSVC/scripts/CaffeLibPostBuild.cmd
+++ b/MSVC/scripts/CaffeLibPostBuild.cmd
@@ -7,13 +7,23 @@ set OUTPUT_DIR=%~3%
 IF /I %CONFIGURATION% == Release (
 echo CaffeLibPostBuild.cmd : copy caffe RELEASE dependencies to output.
 robocopy "%SOLUTION_DIR%libraries\bin" "%OUTPUT_DIR%" caffe*.dll lib*.dll glog.dll snappy.dll vcruntime140.dll /xo /xn /xf *d.dll *d1.dll >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%libraries\lib" "%OUTPUT_DIR%" gflags.dll boost_system*.dll boost_thread*.dll boost_filesystem*.dll boost_python*.dll boost_chrono*.dll /xo /xn /xf *gd*.dll >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%libraries\x64\vc14\bin" "%OUTPUT_DIR%" opencv_core*.dll opencv_imgproc*.dll opencv_imgcodecs*.dll opencv_highgui*.dll opencv_videoio*.dll /xo /xn /xf *d.dll >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%cudnn\cuda\bin" "%OUTPUT_DIR%" cudnn*.dll /xo /xn >nul
+if %errorlevel% geq 8 exit /b 1
+exit /b 0
 ) ELSE (
 echo CaffeLibPostBuild.cmd : copy caffe DEBUG dependencies to output.
 robocopy "%SOLUTION_DIR%libraries\bin" "%OUTPUT_DIR%" caffe*d.dll caffe*d1.dll lib*.dll glogd.dll snappyd.dll vcruntime140.dll /xo /xn /xf  >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%libraries\lib" "%OUTPUT_DIR%" gflagsd.dll boost_system*gd*.dll boost_thread*gd*.dll boost_filesystem*gd*.dll boost_python*gd*.dll boost_chrono*gd*.dll /xo /xn >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%libraries\x64\vc14\bin" "%OUTPUT_DIR%" opencv_core*d.dll opencv_imgproc*d.dll opencv_imgcodecs*d.dll opencv_highgui*d.dll opencv_videoio*d.dll /xo /xn >nul
+if %errorlevel% geq 8 exit /b 1
 robocopy "%SOLUTION_DIR%cudnn\cuda\bin" "%OUTPUT_DIR%" cudnn*.dll /xo /xn  >nul
+if %errorlevel% geq 8 exit /b 1
+exit /b 0
 )

--- a/MSVC/scripts/PyCaffePostBuild.cmd
+++ b/MSVC/scripts/PyCaffePostBuild.cmd
@@ -6,3 +6,5 @@ set OUTPUT_DIR=%~3%
 
 echo PyCaffePostBuild.cmd : copy _caffe.pyd to output
 robocopy "%SOLUTION_DIR%bin\%CONFIGURATION%" "%OUTPUT_DIR%" _caffe.p* /xo /xn >nul
+if %errorlevel% geq 8 exit /b 1
+exit /b 0


### PR DESCRIPTION
1. Add back multiple cuda architecture `compute_35,sm_35;compute_52,sm_52;compute_61,sm_61` to support both new Titan X
2. Update CaffeLibPostBuild.cmd and PyCaffePostBuild.cmd to correctly handle robocopy.exe return code.