### PR TITLE
Update tsv_data_io to support data file cache

### DIFF
--- a/MSVC/caffe.gtest.vcxproj
+++ b/MSVC/caffe.gtest.vcxproj
@@ -348,6 +348,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\src\caffe\test\test_triplet_loss_layer.cpp" />
+    <ClCompile Include="..\src\caffe\test\test_tsv_data_io.cpp" />
     <ClCompile Include="..\src\caffe\test\test_upgrade_proto.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>

--- a/MSVC/caffe.gtest.vcxproj.filters
+++ b/MSVC/caffe.gtest.vcxproj.filters
@@ -234,6 +234,9 @@
     <ClCompile Include="..\src\caffe\test\test_wsgm_loss_layer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\caffe\test\test_tsv_data_io.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\caffe\test\test_gradient_check_util.hpp">

--- a/include/caffe/util/tsv_data_io.hpp
+++ b/include/caffe/util/tsv_data_io.hpp
@@ -21,13 +21,16 @@ using std::string;
 
 namespace caffe {
 
+string ChangeFileExtension(string filename, string ext);
+  
 // for fast readline
 class TextFile
 {
 	vector<char> _buffer;
+  bool _cacheAll;
 
-	int _bufPos;
-	int _bytesInBuffer;
+	int64_t _bufPos;
+	int64_t _bytesInBuffer;
 
 	FILE *_fp;
 
@@ -39,7 +42,7 @@ public:
 
 	bool IsEOF();
 
-	int Open(const char *fname, int buffer_size = 64 * 1024);
+	int Open(const char *fname, bool cache_all);
 	void Close();
 
 	void Seek(int64_t pos);
@@ -61,12 +64,10 @@ class TsvRawDataFile
 	// load line index file to vector lineIndex 
 	int LoadLineIndex(const char *fileName, vector<int64_t> &lineIndex);
 
-	string ChangeFileExtension(string filename, string ext);
-
 public:
 	~TsvRawDataFile();
 
-	int Open(const char *fileName, int colData, int colLabel);
+	int Open(const char *fileName, bool cache_all, int colData, int colLabel);
 	void Close();
 	void ShuffleData(string filename);
 

--- a/src/caffe/layers/tsv_data_layer.cpp
+++ b/src/caffe/layers/tsv_data_layer.cpp
@@ -163,13 +163,13 @@ void TsvDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   //int col_crop = tsv_param.col_crop();
   bool has_separate_label_file = tsv_param.has_source_label();
 
-  tsv_.Open(tsv_data.c_str(), col_data, has_separate_label_file ? -1 : col_label);
+  tsv_.Open(tsv_data.c_str(), tsv_param.cache_all(), col_data, has_separate_label_file ? -1 : col_label);
   if (has_shuffle_file)
     tsv_.ShuffleData(tsv_shuffle);
   if (has_separate_label_file)
   {
 	  string tsv_label = tsv_param.source_label();
-	  tsv_label_.Open(tsv_label.c_str(), -1, col_label);
+	  tsv_label_.Open(tsv_label.c_str(), true, -1, col_label);
 	  if (has_shuffle_file)
         tsv_label_.ShuffleData(tsv_shuffle);
 	  CHECK_EQ(tsv_.TotalLines(), tsv_label_.TotalLines())

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1335,6 +1335,8 @@ message TsvDataParameter{
 	optional CropType crop_type = 15[default = AlexStyle]; // default to AlexStyle crop
 	// Specify the kl file for color jittering
 	optional string color_kl_file = 16;
+	// specify if to cache the tsv file for fast reading
+	optional bool cache_all = 17[default = false]; // default to false (no cache)
 }
 
 message SPPParameter {

--- a/src/caffe/test/test_tsv_data_io.cpp
+++ b/src/caffe/test/test_tsv_data_io.cpp
@@ -1,0 +1,122 @@
+#include "gtest/gtest.h"
+
+#include "caffe/syncedmem.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/tsv_data_io.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+class TsvDataIoTest : public ::testing::Test 
+{
+protected:
+  virtual void SetUp()
+  {
+    MakeTempDir(&source_);
+    source_ += "/test.tsv";
+    string lineidx_file = ChangeFileExtension(source_, "lineidx");
+    string shuffle_file = ChangeFileExtension(source_, "shuffle");
+    LOG(INFO) << "Using temporary tsv file " << source_;
+    
+    FILE *fp_tsv = fopen(source_.c_str(), "w");
+    CHECK(fp_tsv) << "Cannot create temporary tsv file " << source_;
+    FILE *fp_lineidx = fopen(lineidx_file.c_str(), "w");
+    CHECK(fp_lineidx) << "Cannot create lineidx file " << lineidx_file;
+    for (int i = 0; i < 10; i++)
+    {
+      fprintf(fp_lineidx, "%ld\n", ftell(fp_tsv));
+      fprintf(fp_tsv, "%d\t%c\t%c\n", i, 'a' + i, 'A' + i);
+    }
+    fclose(fp_lineidx);
+    fclose(fp_tsv);
+
+    FILE *fp_shuffle = fopen(shuffle_file.c_str(), "w");
+    CHECK(fp_shuffle) << "Cannot create shuffle file " << shuffle_file;
+    for (int i = 0; i < 10; i++)
+      fprintf(fp_shuffle, "%d\n", 9 - i);
+    fclose(fp_shuffle);
+  }
+
+  virtual ~TsvDataIoTest() { }
+
+  void SequentialRead(bool cache_all)
+  {
+    TsvRawDataFile tsv;
+    tsv.Open(this->source_.c_str(), cache_all, 2, 0);
+    for (int n = 0; n < 3; n++)
+    {
+      vector<std::string> base64coded_data;
+      vector<std::string> label;
+      for (int i = 0; i < 100; i++)
+      {
+        if (tsv.ReadNextLine(base64coded_data, label) < 0)
+          break;
+        string data = base64coded_data[i];
+        string lbl = label[i];
+        string _lbl = "0";
+        _lbl[0] += i;
+        string _data = "A";
+        _data[0] += i;
+        EXPECT_EQ(data, _data);
+        EXPECT_EQ(lbl, _lbl);
+      }
+      EXPECT_TRUE(tsv.IsEOF());
+      tsv.MoveToFirst();
+    }
+  }
+
+  void RandomRead(bool cache_all)
+  {
+    TsvRawDataFile tsv;
+    tsv.Open(this->source_.c_str(), cache_all, 2, 0);
+    tsv.ShuffleData(ChangeFileExtension(this->source_, "shuffle"));
+    EXPECT_EQ(tsv.TotalLines(), 10);
+    for (int n = 0; n < 3; n++)
+    {
+      vector<std::string> base64coded_data;
+      vector<std::string> label;
+      for (int i = 0; i < 100; i++)
+      {
+        if (tsv.ReadNextLine(base64coded_data, label) < 0)
+          break;
+        string data = base64coded_data[i];
+        string lbl = label[i];
+        string _lbl = "0";
+        _lbl[0] += 9 - i;
+        string _data = "A";
+        _data[0] += 9 - i;
+        EXPECT_EQ(data, _data);
+        EXPECT_EQ(lbl, _lbl);
+      }
+      EXPECT_TRUE(tsv.IsEOF());
+      tsv.MoveToFirst();
+    }
+  }
+
+  string source_;
+};
+
+
+TEST_F(TsvDataIoTest, TestSequentialRead)
+{
+  SequentialRead(false);
+}
+
+TEST_F(TsvDataIoTest, TestRandomRead)
+{
+  RandomRead(false);
+}
+
+TEST_F(TsvDataIoTest, TestCachedSequentialRead)
+{
+  SequentialRead(true);
+}
+
+TEST_F(TsvDataIoTest, TestCachedRandomRead)
+{
+  RandomRead(true);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
1. added unit test for sequential/random tsv data access, with and without cache.
2. add param cache_all to tsv_data_layer for fast IO throughput.