### PR TITLE
Bug fix for linux compiling and roi-pooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ else
   $(error Cannot static link with the $(CXX) compiler)
 endif
 ifeq ($(USE_PERF_TEST), 1)
-	COMMON_FLAGS += -DPERF_TEST
+	COMMON_FLAGS += -DPERF_TEST -std=c++11
 endif
 # Debugging
 ifeq ($(DEBUG), 1)

--- a/src/caffe/layers/roi_pooling_layer.cu
+++ b/src/caffe/layers/roi_pooling_layer.cu
@@ -41,13 +41,13 @@ __global__ void ROIPoolForward(const int nthreads, const Dtype* bottom_data,
     Dtype bin_size_w = static_cast<Dtype>(roi_width)
                        / static_cast<Dtype>(pooled_width);
 
-    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+    int hstart = static_cast<int>(round(static_cast<Dtype>(ph)
                                         * bin_size_h));
-    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+    int wstart = static_cast<int>(round(static_cast<Dtype>(pw)
                                         * bin_size_w));
-    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+    int hend = static_cast<int>(round(static_cast<Dtype>(ph + 1)
                                      * bin_size_h));
-    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+    int wend = static_cast<int>(round(static_cast<Dtype>(pw + 1)
                                      * bin_size_w));
 
     // Add roi offsets and clip to input boundaries


### PR DESCRIPTION
1. fix the linux compiling failure when PerfTest is enabled.
2. fix the bug of roi calculation in roi-pooling layer