### PR TITLE
Update cudnn pooling layer to fix global pooling

### DIFF
--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -138,6 +138,29 @@ inline void createPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
 }
 
 template <typename Dtype>
+inline void setPoolingDesc(cudnnPoolingDescriptor_t pool_desc,
+    PoolingParameter_PoolMethod poolmethod, cudnnPoolingMode_t* mode,
+    int h, int w, int pad_h, int pad_w, int stride_h, int stride_w) {
+  switch (poolmethod) {
+  case PoolingParameter_PoolMethod_MAX:
+    *mode = CUDNN_POOLING_MAX;
+    break;
+  case PoolingParameter_PoolMethod_AVE:
+    *mode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+    break;
+  default:
+    LOG(FATAL) << "Unknown pooling method.";
+  }
+#if CUDNN_VERSION_MIN(5, 0, 0)
+  CUDNN_CHECK(cudnnSetPooling2dDescriptor(pool_desc, *mode,
+        CUDNN_PROPAGATE_NAN, h, w, pad_h, pad_w, stride_h, stride_w));
+#else
+  CUDNN_CHECK(cudnnSetPooling2dDescriptor_v4(pool_desc, *mode,
+        CUDNN_PROPAGATE_NAN, h, w, pad_h, pad_w, stride_h, stride_w));
+#endif
+}
+
+template <typename Dtype>
 inline void createActivationDescriptor(cudnnActivationDescriptor_t* activ_desc,
     cudnnActivationMode_t mode) {
   CUDNN_CHECK(cudnnCreateActivationDescriptor(activ_desc));

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -27,6 +27,13 @@ void CuDNNPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       this->channels_, this->height_, this->width_);
   cudnn::setTensor4dDesc<Dtype>(&top_desc_, bottom[0]->num(),
       this->channels_, this->pooled_height_, this->pooled_width_);
+  if (this->global_pooling_) {
+    // set pooling desc again, since kernel_h_ and kernel_w_ may have changed.
+    cudnn::setPoolingDesc<Dtype>(pooling_desc_,
+      this->layer_param_.pooling_param().pool(), &mode_,
+      this->kernel_h_, this->kernel_w_, this->pad_h_, this->pad_w_,
+      this->stride_h_, this->stride_w_);
+  }
 }
 
 template <typename Dtype>


### PR DESCRIPTION
When global_pooling is set in the pooling layer, Reshape(...) needs to reset kernel_w_ and kernel_h_ to cover the whole feature map. But in CuDNNPoolingLayer, this is not correctly implemented. This fix ensures the logic in cudnn pooling is consistent with Caffe pooling.