### PR TITLE
fix the crash bug in pycaffe

### DIFF
--- a/include/caffe/layers/python_layer.hpp
+++ b/include/caffe/layers/python_layer.hpp
@@ -26,7 +26,7 @@ class PythonLayer : public Layer<Dtype> {
     }
     self_.attr("param_str") = bp::str(
         this->layer_param_.python_param().param_str());
-    self_.attr("phase") = static_cast<int>(this->phase_);
+    //self_.attr("phase") = static_cast<int>(this->phase_);
     self_.attr("setup")(bottom, top);
   }
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,


### PR DESCRIPTION
fix the error of  "AttributeError: can't set attribute" when 
           self.solver = caffe.SGDSolver(solver_prototxt)