### PR TITLE
Change train/test memory optimization to default in net.cpp

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -285,7 +285,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
   ShareWeights();
   debug_info_ = param.debug_info();
 
-  opt_train_memory_ = true; //param.opt_train_memory();
+  opt_train_memory_ = param.opt_train_memory();
   opt_test_memory_ = param.opt_test_memory();
   shared_blobs_.clear();
   shared_record_.clear();


### PR DESCRIPTION
This is to avoid the impact to faster-rcnn pipeline. If needed, especially for resnet, this can be turned on at the beginning of prototxt file by setting:
opt_train_memory: true
opt_test_memory: true