### PR TITLE
Add c++ 11 support in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ include(cmake/Dependencies.cmake)
 
 # ---[ Flags
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -std=c++11")
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
 endif()
 
 caffe_set_caffe_link()


### PR DESCRIPTION
This PR adds C++ 11 support to CMakeLists.txt. However, it will introduce warnings "cc1: warning: command line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C" when compiling Caffe, which is because CMAKE_CXX_FLAGS is also used for gcc. 

I do not have a solution for this right now, but this warning does not really matter in compilation anyway.

Without this change, I cannot build Caffe using Cmake in Linux. Let me know if I miss anything.