### PR TITLE
Fix for Visual Studio build, backward and implicit loss weight

### DIFF
--- a/include/caffe/layers/tree_prediction_layer.hpp
+++ b/include/caffe/layers/tree_prediction_layer.hpp
@@ -59,12 +59,20 @@ protected:
     /// @brief Not implemented (non-differentiable function)
     virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
                               const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-        NOT_IMPLEMENTED;
+        for (int i = 0; i < propagate_down.size(); ++i) {
+            if (propagate_down[i]) {
+                NOT_IMPLEMENTED;
+            }
+        }
     }
     /// @brief Not implemented (non-differentiable function)
     virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
                               const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-        NOT_IMPLEMENTED;
+        for (int i = 0; i < propagate_down.size(); ++i) {
+            if (propagate_down[i]) {
+                NOT_IMPLEMENTED;
+            }
+        }
     }
 
     int outer_num_;

--- a/src/caffe/layers/roi_pooling_layer.cpp
+++ b/src/caffe/layers/roi_pooling_layer.cpp
@@ -127,7 +127,11 @@ void ROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void ROIPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  NOT_IMPLEMENTED;
+    for (int i = 0; i < propagate_down.size(); ++i) {
+        if (propagate_down[i]) {
+            NOT_IMPLEMENTED;
+        }
+    }
 }
 
 

--- a/src/caffe/layers/softmaxtree_loss_layer.cpp
+++ b/src/caffe/layers/softmaxtree_loss_layer.cpp
@@ -10,6 +10,12 @@ namespace caffe {
 template <typename Dtype>
 void SoftmaxTreeWithLossLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
     LossLayer<Dtype>::LayerSetUp(bottom, top);
+    if (this->layer_param_.loss_weight_size() == 1 && top.size() > 1) {
+        // only the first top is loss
+        auto ignored_tops = std::min((int)top.size(), MaxTopBlobs());
+        for (int i = 1; i < ignored_tops; ++i)
+            this->layer_param_.add_loss_weight(Dtype(0));
+    }
     LayerParameter softmaxtree_param(this->layer_param_);
     softmaxtree_param.clear_loss_weight(); // Ignore loss_wight if set
     softmaxtree_param.set_type("SoftmaxTree");

--- a/src/caffe/layers/tsv_box_data_layer.cpp
+++ b/src/caffe/layers/tsv_box_data_layer.cpp
@@ -698,11 +698,14 @@ void fill_truth_detection(const string &input_label_data, float *truth, int num_
         int nw, int nh, int network_w, int network_h, float odx, float ody)
 {
     vector<box_label> boxes = read_boxes(input_label_data, labelmap, orig_img_w, orig_img_h);
-    randomize_boxes(&boxes[0], boxes.size());
-    correct_boxes(&boxes[0], boxes.size(), dx, dy, sx, sy, flip, rad, 
+    auto count = boxes.size();
+    if (!count)
+        return;
+    randomize_boxes(&boxes[0], count);
+    correct_boxes(&boxes[0], count, dx, dy, sx, sy, flip, rad,
             orig_img_w, orig_img_h, nw, nh, network_w, network_h, odx, ody);
-    int count = boxes.size();
-    if (count > num_boxes) count = num_boxes;
+    if (count > num_boxes) 
+        count = num_boxes;
     float x, y, w, h;
     int id;
     int i;

--- a/src/caffe/util/tsv_data_io.cpp
+++ b/src/caffe/util/tsv_data_io.cpp
@@ -392,10 +392,9 @@ bool MultiSourceTsvRawDataFile::IsEOF() {
 
 void MultiSourceTsvRawDataFile::EnsureShuffleDataInitialized() {
     if (_shuffleLines.size() == 0) {
-        for (size_t i = 0; i < _dataFiles.size(); i++) {
-            for (size_t j = 0; j < _dataFiles[i]->TotalLines(); j++) {
-                _shuffleLines.push_back(std::make_pair<int64_t, int64_t>(
-                            i, j));
+        for (int64_t i = 0; i < _dataFiles.size(); i++) {
+            for (int64_t j = 0; j < _dataFiles[i]->TotalLines(); j++) {
+                _shuffleLines.emplace_back(i, j);
             }
         }
     }


### PR DESCRIPTION
Fix to compile for Windows (Visual Studio)
Fix for backward to rely on propagate_down (to be able to call `caffe test`)
Fix for case when box is empty in tsv