### PR TITLE
Allow force_backward only for the first bottom.

### DIFF
--- a/include/caffe/layers/softmaxtree_loss_layer.hpp
+++ b/include/caffe/layers/softmaxtree_loss_layer.hpp
@@ -59,6 +59,10 @@ class SoftmaxTreeWithLossLayer : public LossLayer<Dtype> {
       }
       return 2;
   }
+  virtual inline bool AllowForceBackward(const int bottom_index) const {
+      // This is a loss layer with potentially 3 bottoms, only the first one can ever have backward
+      return bottom_index == 0;
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,


### PR DESCRIPTION
SoftmaxTreeLoss layer with objectness could have 3 bottoms, the default LossLayer only considers up to 2 bottoms.

force_backward is used in verification/correctness tests.
