### PR TITLE
Bug fix for the issues from invalid box and single data source. 

### DIFF
--- a/src/caffe/layers/tsv_box_data_layer.cpp
+++ b/src/caffe/layers/tsv_box_data_layer.cpp
@@ -567,8 +567,8 @@ vector<box_label> read_boxes(const string &input_label_data, map<string, int> &l
         float y = ((rect[1] + rect[3]) / 2) / orig_img_h;
         float w = (rect[2] - rect[0]) / orig_img_w;
         float h = (rect[3] - rect[1]) / orig_img_h;
-
-        if (x < 0 || y < 0 || x > 0.999 || y > 0.999 || w <= 0 || h <= 0) {
+        
+        if (x < -0.001 || y < -0.001 || x > 0.999 || y > 0.999 || w <= -0.001 || h <= -0.001) {
             LOG(ERROR) << "invalid bounding box detected and will be skipped: " 
                 << rect[0] << ", " << rect[1] << ", " 
                 << rect[2] << ", " << rect[3];

--- a/src/caffe/util/tsv_data_io.cpp
+++ b/src/caffe/util/tsv_data_io.cpp
@@ -163,7 +163,15 @@ int TsvRawDataFile::LoadLineIndex(const char *fileName, vector<int64_t> &lineInd
 		if (line.length() == 0)
 			break;
 
-		lineIndex.push_back(atoll(line.c_str()));
+        vector<string> parts;
+        boost::split(parts, line, boost::is_any_of("\t"));
+        if (parts.size() == 1) {
+            lineIndex.push_back(atoll(parts[0].c_str()));
+        } else if (parts.size() == 2) {
+            // this is multi-source type but with only one 
+            CHECK_EQ(atoll(parts[0].c_str()), 0);
+            lineIndex.push_back(atoll(parts[1].c_str()));
+        }
 	}
 
 	index_file.close();


### PR DESCRIPTION
[bug fix in tsv io] support the single tsv source with composite version  of shuffle file 

[tsv box] relax the requirement to validate the bounding boxes