### PR TITLE
data parameters to manually override world size and rank.

### DIFF
--- a/include/caffe/layers/data_layer.hpp
+++ b/include/caffe/layers/data_layer.hpp
@@ -35,6 +35,9 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   shared_ptr<db::DB> db_;
   shared_ptr<db::Cursor> cursor_;
   uint64_t offset_;
+  // world size and rank override
+  uint32_t world_size_;
+  uint32_t world_rank_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/hdf5_data_layer.hpp
+++ b/include/caffe/layers/hdf5_data_layer.hpp
@@ -23,7 +23,7 @@ template <typename Dtype>
 class HDF5DataLayer : public Layer<Dtype> {
  public:
   explicit HDF5DataLayer(const LayerParameter& param)
-      : Layer<Dtype>(param), offset_() {}
+      : Layer<Dtype>(param), offset_(), world_size_(1), world_rank_(0) {}
   virtual ~HDF5DataLayer();
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
@@ -59,6 +59,9 @@ class HDF5DataLayer : public Layer<Dtype> {
   std::vector<unsigned int> data_permutation_;
   std::vector<unsigned int> file_permutation_;
   uint64_t offset_;
+  // world size and rank override
+  uint32_t world_size_;
+  uint32_t world_rank_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/tsv_data_layer.hpp
+++ b/include/caffe/layers/tsv_data_layer.hpp
@@ -23,7 +23,7 @@ template <typename Dtype>
 class TsvDataLayer : public BasePrefetchingDataLayer<Dtype> {
 public:
 	explicit TsvDataLayer(const LayerParameter& param)
-		: BasePrefetchingDataLayer<Dtype>(param), offset_() {}
+		: BasePrefetchingDataLayer<Dtype>(param), offset_(), world_size_(1), world_rank_(0) {}
 	virtual ~TsvDataLayer();
 	virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
 		const vector<Blob<Dtype>*>& top);
@@ -47,6 +47,10 @@ protected:
 
     // mean values for pixel value subtraction
     std::vector<Dtype> mean_values_;
+
+    // world size and rank override
+    uint32_t world_size_;
+    uint32_t world_rank_;
 
 private:
     void load_kl(const string &kl_filename);

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -14,7 +14,7 @@ namespace caffe {
 template <typename Dtype>
 DataLayer<Dtype>::DataLayer(const LayerParameter& param)
   : BasePrefetchingDataLayer<Dtype>(param),
-    offset_() {
+    offset_(), world_size_(1), world_rank_(0) {
   db_.reset(db::GetDB(param.data_param().backend()));
   db_->Open(param.data_param().source(), db::READ);
   cursor_.reset(db_->NewCursor());
@@ -28,6 +28,14 @@ DataLayer<Dtype>::~DataLayer() {
 template <typename Dtype>
 void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  const DataParameter &data_param = this->layer_param().data_param();
+  CHECK_EQ(data_param.has_world_size(), data_param.has_world_rank())
+      << "world_size and world_rank must be specified together";
+  world_size_ = data_param.world_size();
+  world_rank_ = data_param.world_rank();
+  CHECK_LT(world_rank_, world_size_);
+  CHECK_GT(world_size_, 0);
+
   const int batch_size = this->layer_param_.data_param().batch_size();
   // Read a data point, and use it to initialize the top blob.
   Datum datum;
@@ -58,11 +66,12 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 bool DataLayer<Dtype>::Skip() {
-  int size = Caffe::solver_count();
-  int rank = Caffe::solver_rank();
-  bool keep = (offset_ % size) == rank ||
-              // In test mode, only rank 0 runs, so avoid skipping
-              this->layer_param_.phase() == TEST;
+  // In test mode, only rank 0 (of each node) runs, so avoid skipping within a node
+  if (this->layer_param_.phase() == TEST)
+      return offset_ % world_size_ != 0;  // for world_size == 1, this is always false
+  int size = Caffe::solver_count() * world_size_;
+  int rank = Caffe::solver_count() * world_rank_ + Caffe::solver_rank();
+  bool keep = (offset_ % size) == rank;
   return !keep;
 }
 

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -72,7 +72,16 @@ void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  // Refuse transformation parameters since HDF5 is totally generic.
+
+  const HDF5DataParameter &hdf5_param = this->layer_param().hdf5_data_param();
+  CHECK_EQ(hdf5_param.has_world_size(), hdf5_param.has_world_rank())
+      << "world_size and world_rank must be specified together";
+  world_size_ = hdf5_param.world_size();
+  world_rank_ = hdf5_param.world_rank();
+  CHECK_LT(world_rank_, world_size_);
+  CHECK_GT(world_size_, 0);
+
+    // Refuse transformation parameters since HDF5 is totally generic.
   CHECK(!this->layer_param_.has_transform_param()) <<
       this->type() << " does not transform data.";
   // Read the source to parse the filenames.
@@ -127,11 +136,12 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 bool HDF5DataLayer<Dtype>::Skip() {
-  int size = Caffe::solver_count();
-  int rank = Caffe::solver_rank();
-  bool keep = (offset_ % size) == rank ||
-              // In test mode, only rank 0 runs, so avoid skipping
-              this->layer_param_.phase() == TEST;
+  // In test mode, only rank 0 (of each node) runs, so avoid skipping within a node
+  if (this->layer_param_.phase() == TEST)
+      return offset_ % world_size_ != 0;  // for world_size == 1, this is always false
+  int size = Caffe::solver_count() * world_size_;
+  int rank = Caffe::solver_count() * world_rank_ + Caffe::solver_rank();
+  bool keep = (offset_ % size) == rank;
   return !keep;
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -797,6 +797,10 @@ message DataParameter {
   // Prefetch queue (Increase if data feeding bandwidth varies, within the
   // limit of device memory for GPU training)
   optional uint32 prefetch = 10 [default = 4];
+  // override size for data instrumentation
+  optional uint32 world_size = 190 [default = 1];
+  // override rank for data instrumentation
+  optional uint32 world_rank = 200 [default = 0];
 }
 
 message DenseLossParameter {
@@ -899,6 +903,11 @@ message HDF5DataParameter {
   // but data between different files are not interleaved; all of a file's
   // data are output (in a random order) before moving onto another file.
   optional bool shuffle = 3 [default = false];
+
+  // override size for data instrumentation
+  optional uint32 world_size = 190 [default = 1];
+  // override rank for data instrumentation
+  optional uint32 world_rank = 200 [default = 0];
 }
 
 message HDF5OutputParameter {
@@ -1469,6 +1478,10 @@ message TsvDataParameter{
     // specify the output pixel value scale. Default is 255, but it can be also set to 1 with mean value (0,0,0) to
     // limit the pixel value to be in [0,1].
     optional float pixel_value_scale = 18 [default = 255];
+	// override size for data instrumentation
+	optional uint32 world_size = 190 [default = 1];
+	// override rank for data instrumentation
+	optional uint32 world_rank = 200 [default = 0];
 }
 
 message BoxDataParameter {


### PR DESCRIPTION
This is needed for instrumenting Caffe as data layer provider (e.g. for PyTorch), but will be also useful in Caffe-MPI branch as a manual override.